### PR TITLE
Change global scope to script to keep things contained

### DIFF
--- a/PlannerModule/PlannerModule.psm1
+++ b/PlannerModule/PlannerModule.psm1
@@ -10,23 +10,23 @@
 #>
 
 
-	<#	
+	<#
 		===========================================================================
 		 Created on:   	6/3/2019 1:55 AM
 		 Created by:   	Zeng Yinghua
-		 Organization: 	
+		 Organization:
 		 Filename:     	PlannerModule.psm1
 		-------------------------------------------------------------------------
 		 Module Name: PlannerModule
 		===========================================================================
-	
+
 	#>
-	
+
 	function Get-PlannerAuthToken
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
-		Write-Host "Checking for AzureAD module..." 
+
+		Write-Host "Checking for AzureAD module..."
 		$AadModule = Get-Module -Name "AzureAD" -ListAvailable
 		if ($AadModule -eq $null)
 		{
@@ -39,16 +39,16 @@
 			Write-Error "Install by running 'Install-Module AzureAD' or 'Install-Module AzureADPreview' from an elevated PowerShell prompt"
 			exit
 		}
-		
+
 		# Getting path to ActiveDirectory Assemblies
 		# If the module count is greater than 1 find the latest version
-		
+
 		if ($AadModule.count -gt 1)
 		{
 			$Latest_Version = ($AadModule | Select-Object version | Sort-Object)[-1]
 			$aadModule = $AadModule | ForEach-Object { $_.version -eq $Latest_Version.version }
-			
-			# Checking if there are multiple versions of the same module found		
+
+			# Checking if there are multiple versions of the same module found
 			if ($AadModule.count -gt 1)
 			{
 				$aadModule = $AadModule | Select-Object -Unique
@@ -61,10 +61,10 @@
 			$adal = Join-Path $AadModule.ModuleBase "Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
 			$adalforms = Join-Path $AadModule.ModuleBase "Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll"
 		}
-		
+
 		[System.Reflection.Assembly]::LoadFrom($adal) | Out-Null
 		[System.Reflection.Assembly]::LoadFrom($adalforms) | Out-Null
-		
+
 		if ($PlannerEnvUpdated -ne $true)
 		{
 			$clientId = "3556cd23-09eb-42b3-a3b9-72cba5c7926e"
@@ -72,21 +72,21 @@
 		$redirectUri = "urn:ietf:wg:oauth:2.0:oob"
 		$resourceAppIdURI = "https://graph.microsoft.com"
 		$authority = "https://login.microsoftonline.com/common"
-		
+
 		try
 		{
 			$authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authority
-			
+
 			# https://msdn.microsoft.com/en-us/library/azure/microsoft.identitymodel.clients.activedirectory.promptbehavior.aspx
 			# Change the prompt behaviour to force credentials each time: Auto, Always, Never, RefreshSession
-			
+
 			$platformParameters = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList "Always"
 			$authResult = $authContext.AcquireTokenAsync($resourceAppIdURI, $clientId, $redirectUri, $platformParameters).Result
-			
-			# If the accesstoken is valid then create the authentication header		
+
+			# If the accesstoken is valid then create the authentication header
 			if ($authResult.AccessToken)
 			{
-				# Creating header for Authorization token			
+				# Creating header for Authorization token
 				$authHeader = @{
 					'Content-Type'  = 'application/json'
 					'Authorization' = "Bearer " + $authResult.AccessToken
@@ -107,20 +107,20 @@
 			break
 		}
 	}
-	
+
 	function Update-PlannerModuelEnvironment
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[cmdletbinding()]
 		param
 		(
 			[Parameter(Mandatory = $false)]
 			[string]$ClientId
 		)
-		
+
 		Write-Warning "WARNING: Call the 'Connect-Planner' cmdlet to use the updated environment parameters."
-		
+
 		Write-Host "
 	AuthUrl          : https://login.microsoftonline.com/common
 	ResourceId       : https://graph.microsoft.com
@@ -130,15 +130,15 @@
 	SchemaVersion    : beta
 
 "
-		$Global:ClientId = $($ClientId)
-		$Global:PlannerEnvUpdated = $true
+		$Script:ClientId = $($ClientId)
+		$Script:PlannerEnvUpdated = $true
 	}
-	
-	
+
+
 	Function Invoke-ListUnifiedGroups
 	{
-		# .ExternalHelp PlannerModule.psm1-Help.xml	
-		
+		# .ExternalHelp PlannerModule.psm1-Help.xml
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/Groups?`$filter=groupTypes/any(c:c+eq+'Unified')"
@@ -154,13 +154,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function New-AADUnifiedGroup
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[cmdletbinding()]
 		param
 		(
@@ -171,10 +171,10 @@
 			[ValidateSet("Public", "Private")]
 			$visibility = "Private"
 		)
-		
+
 		$randomNum = (Get-Random -Maximum 1000).tostring()
 		$mailNickname = $GroupName.Replace(" ", "") + $randomNum
-		
+
 		try
 		{
 			$Body = @"
@@ -190,7 +190,7 @@
   "visibility": "Private"
 }
 "@
-			
+
 			$uri = "https://graph.microsoft.com/beta/groups"
 			Invoke-RestMethod -Uri $uri -Headers $authToken -Method POST -Body $Body
 		}
@@ -204,13 +204,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function Add-AADUnifiedGroupMember
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[cmdletbinding()]
 		param
 		(
@@ -219,20 +219,20 @@
 			[Parameter(Mandatory = $True)]
 			[array]$UserPrincipalNames
 		)
-		
-		
-		
+
+
+
 		#Get Group ID
 		$GroupID = (Get-PlannerPlanGroup -GroupName $GroupName).id
-		
+
 		foreach ($UserPrincipalName in $UserPrincipalNames)
 		{
 			try
 			{
-				
+
 				#Get users id
 				$userID = (Get-AADUser -UserPrincipalName $UserPrincipalName).id
-				
+
 				$Body = @"
 {
   "@odata.id": "https://graph.microsoft.com/beta/directoryObjects/$($userID)"
@@ -252,19 +252,19 @@
 				break
 			}
 		}
-		
+
 	}
-	
+
 	Function Get-PlannerPlanGroup
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[cmdletbinding()]
 		param
 		(
 			[string]$GroupName
 		)
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/Groups?`$filter=groupTypes/any(c:c+eq+'Unified')+and+displayName+eq+`'$Groupname`'"
@@ -280,13 +280,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function Invoke-ListPlannerPlans
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -296,7 +296,7 @@
 			[Parameter(Mandatory = $True, ParameterSetName = 'GroupName')]
 			$GroupName
 		)
-		
+
 		Process
 		{
 			try
@@ -323,11 +323,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerPlan
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -335,7 +335,7 @@
 			[Alias("id")]
 			[string[]]$PlanID
 		)
-		
+
 		Process
 		{
 			try
@@ -355,11 +355,11 @@
 			}
 		}
 	}
-	
+
 	Function Invoke-ListPlannerPlanTasks
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -367,12 +367,12 @@
 			[Alias("id")]
 			[string[]]$PlanID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/plans/$PlanID/tasks"
 				(Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 			}
@@ -387,13 +387,13 @@
 				break
 			}
 		}
-		
+
 	}
-	
+
 	Function Invoke-ListPlannerPlanBuckets
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -401,12 +401,12 @@
 			[Alias("id")]
 			[string[]]$PlanID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/plans/$PlanID/buckets"
 				(Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 			}
@@ -422,11 +422,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerTask
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -434,12 +434,12 @@
 			[Alias("id")]
 			[string[]]$TaskID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/tasks/$TaskID"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -455,11 +455,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerTaskDetails
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -467,12 +467,12 @@
 			[Alias("id")]
 			[string[]]$TaskID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta//planner/tasks/$TaskID/details"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -488,11 +488,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerPlanDetails
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -500,12 +500,12 @@
 			[Alias("id")]
 			[string[]]$PlanID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/plans/$PlanID/details"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -521,11 +521,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerBucket
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -533,12 +533,12 @@
 			[Alias("id")]
 			[string[]]$BucketID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/buckets/$BucketID"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -554,11 +554,11 @@
 			}
 		}
 	}
-	
+
 	Function Invoke-ListPlannerBucketTasks
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -566,12 +566,12 @@
 			[Alias("id")]
 			[string[]]$BucketID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/buckets/$BucketID/tasks"
 				(Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get).value
 			}
@@ -587,11 +587,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerAssignedToTaskBoardTaskFormat
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -599,12 +599,12 @@
 			[Alias("id")]
 			[string[]]$TaskID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/tasks/$TaskID/assignedToTaskBoardFormat"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -620,11 +620,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerBucketTaskBoardTaskFormat
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -632,12 +632,12 @@
 			[Alias("id")]
 			[string[]]$TaskID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/tasks/$TaskID/bucketTaskBoardFormat"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -653,11 +653,11 @@
 			}
 		}
 	}
-	
+
 	Function Get-PlannerProgressTaskBoardTaskFormat
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -665,12 +665,12 @@
 			[Alias("id")]
 			[string[]]$TaskID
 		)
-		
+
 		Process
 		{
 			try
 			{
-				
+
 				$uri = "https://graph.microsoft.com/beta/planner/tasks/$TaskID/progressTaskBoardFormat"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method Get
 			}
@@ -686,15 +686,15 @@
 			}
 		}
 	}
-	
+
 	Function New-PlannerPlan
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
-			
+
 			[Parameter(Mandatory = $true)]
 			$PlanName,
 			[Parameter(Mandatory = $True)]
@@ -702,8 +702,8 @@
 			[ValidateSet("Public", "Private")]
 			$visibility = "Private"
 		)
-		
-		
+
+
 		$GroupInfo = Get-PlannerPlanGroup -GroupName $($PlanName) -ErrorAction SilentlyContinue
 		if ($GroupInfo)
 		{
@@ -720,15 +720,15 @@
 			$GroupID = $results.id
 			Start-Sleep 10
 		}
-		
-		
+
+
 		$Body = @"
 {
   "owner": "$($GroupID)",
   "title": "$($PlanName)"
 }
 "@
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/planner/plans"
@@ -745,28 +745,28 @@
 			break
 		}
 	}
-	
+
 	Function New-PlannerPlanToGroup
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
-			
+
 			[Parameter(Mandatory = $true)]
 			$PlanName,
 			[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $True)]
 			[Alias("id")]
 			$GroupID
 		)
-		
+
 		#Add current user to group
 		#Get current user
 		$uri = "https://graph.microsoft.com/beta/me"
 		$UserID = (Invoke-RestMethod -Uri $uri -Headers $authToken -Method GET).id
 		$uri = "https://graph.microsoft.com/beta/Groups/$GroupID/members?`$filter=id eq '$UserID'"
-		
+
 		try
 		{
 			Invoke-RestMethod -Uri $uri -Headers $authToken -Method GET
@@ -784,11 +784,11 @@
   "@odata.id": "https://graph.microsoft.com/beta/directoryObjects/$($userID)"
 }
 "@
-	
+
 				$uri = "https://graph.microsoft.com/beta/groups/$GroupID/members/`$ref"
 				Invoke-RestMethod -Uri $uri -Headers $authToken -Method POST -Body $Body
 				Start-Sleep 10
-			}		
+			}
 			catch
 			{
 				$ex = $_.Exception
@@ -800,14 +800,14 @@
 				break
 			}
 		}
-		
+
 		$Body = @"
 {
   "owner": "$($GroupID)",
   "title": "$($PlanName)"
 }
 "@
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/planner/plans"
@@ -824,11 +824,11 @@
 			break
 		}
 	}
-	
+
 	Function New-PlannerBucket
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -838,7 +838,7 @@
 			[Parameter(Mandatory = $True)]
 			$BucketName
 		)
-		
+
 		Process
 		{
 			$Body = @"
@@ -848,7 +848,7 @@
   "orderHint": " !"
 }
 "@
-			
+
 			try
 			{
 				$uri = "https://graph.microsoft.com/beta/planner/buckets"
@@ -866,11 +866,11 @@
 			}
 		}
 	}
-	
+
 	Function New-PlannerTask
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -886,13 +886,13 @@
 			[Parameter(Mandatory = $False, HelpMessage = "DateTime format needs to be YYYY-MM-DD, example 2019-06-30")]
 			[DateTime]$dueDate
 		)
-		
+
 		#user defualt bucket name To do
 		If (!$BucketID)
 		{
 			$BucketID = (Invoke-ListPlannerPlanBuckets -PlanID $($PlanID) | Where-Object { $_.name -like 'To do' }).id
 		}
-		
+
 		#if start date and due date is not definde
 		if (!$startDate -and !$dueDate)
 		{
@@ -904,13 +904,13 @@
 }
 "@
 		}
-		
+
 		#if start date is due date are definded
 		if ($startDate -and $dueDate)
 		{
 			$startDateformat = $startDate.ToString("yyyy-MM-ddT10:00:00Z")
 			$dueDateformat = $dueDate.ToString("yyyy-MM-ddT10:00:00Z")
-			
+
 			$Body = @"
 {
     "planId": "$($PlanID)",
@@ -921,12 +921,12 @@
 }
 "@
 		}
-		
+
 		#if no start date, but has duedate
 		if (!$startDate -and $dueDate)
 		{
 			$dueDateformat = $dueDate.ToString("yyyy-MM-ddT10:00:00Z")
-			
+
 			$Body = @"
 {
   "planId": "$($PlanID)",
@@ -936,12 +936,12 @@
 }
 "@
 		}
-		
+
 		#if has start date, but no due date
 		if ($startDate -and !$dueDate)
 		{
 			$startDateformat = $startDate.ToString("yyyy-MM-ddT10:00:00Z")
-			
+
 			$Body = @"
 {
   "planId": "$($PlanID)",
@@ -951,7 +951,7 @@
 }
 "@
 		}
-		
+
 		#Make graph call
 		try
 		{
@@ -969,19 +969,19 @@
 			break
 		}
 	}
-	
+
 	Function Get-AADUser
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
 			[Parameter(Mandatory = $True)]
 			$UserPrincipalName
 		)
-		
-		
+
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/users?`$filter=userPrincipalName eq '$($UserPrincipalName)'"
@@ -998,11 +998,11 @@
 			break
 		}
 	}
-	
+
 	Function Invoke-AssignPlannerTask
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -1012,16 +1012,16 @@
 			[Parameter(Mandatory = $True)]
 			[array]$UserPrincipalNames
 		)
-		
+
 		foreach ($UserPrincipalName in $UserPrincipalNames)
 		{
 			#Get users id
 			$userID = (Get-AADUser -UserPrincipalName $UserPrincipalName).id
-			
+
 			#Get Task details
 			$respond = Get-PlannerTask -TaskID $TaskID
 			$ETag = $respond.'@odata.etag'
-			
+
 			$Body = @"
 {
   "assignments": {
@@ -1035,7 +1035,7 @@
 			#Add if-match to new tocket header
 			$NewToken = $authToken.Clone()
 			$NewToken.add("If-Match", $ETag)
-			
+
 			try
 			{
 				$uri = "https://graph.microsoft.com/beta/planner/tasks/$($TaskID)"
@@ -1053,11 +1053,11 @@
 			}
 		}
 	}
-	
+
 	Function Update-PlannerPlanCategories
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -1072,11 +1072,11 @@
 			$category5 = 'null',
 			$category6 = 'null'
 		)
-		
+
 		#Get Plan details
 		$respond = Get-PlannerPlanDetails -PlanID $PlanID
 		$ETag = $respond.'@odata.etag'
-		
+
 		$Body = @"
 {
   "categoryDescriptions": {
@@ -1089,16 +1089,16 @@
   }
 }
 "@
-		
+
 		#Add if-match to new tocket header
 		$NewToken = $authToken.Clone()
 		$NewToken.add("If-Match", $ETag)
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/planner/plans/$($PlanID)/details"
 			Invoke-RestMethod -Uri $uri -Headers $NewToken -Method PATCH -Body $Body
-	
+
 		}
 		catch
 		{
@@ -1110,13 +1110,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function Invoke-AssignPlannerTaskCategories
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -1131,11 +1131,11 @@
 			[bool]$category5 = $false,
 			[bool]$category6 = $false
 		)
-		
+
 		#Get Task details
 		$respond = Get-PlannerTask -TaskID $TaskID
 		$ETag = $respond.'@odata.etag'
-		
+
 		$Body = @"
 {
   "appliedCategories": {
@@ -1148,11 +1148,11 @@
   }
 }
 "@
-		
+
 		#Add if-match to new tocket header
 		$NewToken = $authToken.Clone()
 		$NewToken.add("If-Match", $ETag)
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/planner/tasks/$($TaskID)"
@@ -1168,13 +1168,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function Add-PlannerTaskDescription
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -1184,21 +1184,21 @@
 			[Parameter(Mandatory = $True)]
 			[string[]]$Description
 		)
-		
+
 		#Get Task details
 		$respond = Get-PlannerTaskDetails -TaskID $TaskID
 		$ETag = $respond.'@odata.etag'
-		
+
 		$Body = @"
 {
     "description": "$($Description)"
 }
 "@
-		
+
 		#Add if-match to new tocket header
 		$NewToken = $authToken.Clone()
 		$NewToken.add("If-Match", $ETag)
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/planner/tasks/$($TaskID)/Details"
@@ -1214,13 +1214,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function Add-PlannerTaskChecklist
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		param
 		(
@@ -1231,13 +1231,13 @@
 			[string[]]$Title,
 			[bool]$IsChecked = $false
 		)
-		
+
 		#Get Task details
 		$respond = Get-PlannerTaskDetails -TaskID $TaskID
 		$ETag = $respond.'@odata.etag'
-		
+
 		$checklist = (New-Guid).Guid
-		
+
 		$Body = @"
 {
     "checklist": {
@@ -1249,11 +1249,11 @@
     }
 }
 "@
-		
+
 		#Add if-match to new tocket header
 		$NewToken = $authToken.Clone()
 		$NewToken.add("If-Match", $ETag)
-		
+
 		try
 		{
 			$uri = "https://graph.microsoft.com/beta/planner/tasks/$($TaskID)/Details"
@@ -1269,13 +1269,13 @@
 			Write-Error "Request to $Uri failed with HTTP Status $($ex.Response.StatusCode) $($ex.Response.StatusDescription)"
 			break
 		}
-		
+
 	}
-	
+
 	Function Connect-Planner
 	{
 		# .ExternalHelp PlannerModule.psm1-Help.xml
-		
+
 		[CmdletBinding()]
 		[OutputType([Bool])]
 		Param
@@ -1285,37 +1285,37 @@
 			[ValidateSet($false, $true)]
 			$ForceNonInteractive
 		)
-		
-		
+
+
 		#region Authentication
-		
+
 		if ($ForceNonInteractive -eq $true)
 		{
 			# Getting the authorization token
-			$global:authToken = Get-PlannerAuthToken
+			$Script:authToken = Get-PlannerAuthToken
 		}
-		
+
 		# Checking if authToken exists before running authentication
-		if ($global:authToken)
+		if ($Script:authToken)
 		{
 			# Setting DateTime to Universal time to work in all timezones
 			$DateTime = (Get-Date).ToUniversalTime()
-			
+
 			# If the authToken exists checking when it expires
 			$TokenExpires = ($authToken.ExpiresOn.datetime - $DateTime).Minutes
 			if ($TokenExpires -le 0)
 			{
 				Write-Host "Authentication Token expired" $TokenExpires "minutes ago"
-				$global:authToken = Get-PlannerAuthToken
+				$Script:authToken = Get-PlannerAuthToken
 			}
 		}
 		# Authentication doesn't exist, calling Get-AuthToken function
 		else
 		{
 			# Getting the authorization token
-			$global:authToken = Get-PlannerAuthToken -User $User
+			$Script:authToken = Get-PlannerAuthToken -User $User
 		}
 		#endregion
-		
+
 		####################################################
 	}


### PR DESCRIPTION
Using the Global scope can lead to things being changed by the user when you don't want them to and you can achieve the same effect but in a much safer way using Script scope instead. It'll make the variables available within the module and much more difficult for the user to break them. If there is a need for the user to change these values without calling Connect-Planner or similar then functions can be provided to allow retrieval and editing.