### PR TITLE
Update manifest metadata for gallery and other language modes

### DIFF
--- a/PlannerModule/PlannerModule.psd1
+++ b/PlannerModule/PlannerModule.psd1
@@ -108,13 +108,13 @@
 	) #For performance, list functions explicitly
 	
 	# Cmdlets to export from this module
-	CmdletsToExport = '*' 
+	CmdletsToExport = @()
 	
 	# Variables to export from this module
-	VariablesToExport = '*'
+	VariablesToExport = @()
 	
 	# Aliases to export from this module
-	AliasesToExport = '*' #For performance, list alias explicitly
+	AliasesToExport = @() #For performance, list alias explicitly
 	
 	# DSC class resources to export from this module.
 	#DSCResourcesToExport = ''

--- a/PlannerModule/PlannerModule.psd1
+++ b/PlannerModule/PlannerModule.psd1
@@ -135,10 +135,10 @@
 			Tags = 'PSModule', 'Planner', 'MSGraph'
 			
 			# A URL to the license for this module.
-			# LicenseUri = ''
+			LicenseUri = 'https://github.com/sandytsang/PlannerModule/blob/master/LICENSE'
 			
 			# A URL to the main website for this project.
-			# ProjectUri = ''
+			ProjectUri = 'https://github.com/sandytsang/PlannerModule'
 			
 			# A URL to an icon representing this module.
 			# IconUri = ''


### PR DESCRIPTION
Minor changes to the manifest to allow linking the PowerShell Gallery back to the repo, this should help users find where to go if they want to contribute to this project.

I've also made use of @() instead of * for exported items to ensure that the module can run in ConstrainedLanguageMode. It might not be a likely case right now but is becoming a more common way people run code, especially in automation that could be running against external services such as this.